### PR TITLE
Update webview redaction to use `webviewRedactedViews`

### DIFF
--- a/Cobrowse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cobrowse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cobrowseio/cobrowse-sdk-ios-binary.git",
       "state" : {
-        "revision" : "93bf3d80956b4cc210448d90db97f0238160469c",
-        "version" : "2.27.4"
+        "revision" : "102ef0ff56244d69d0e2dddd5d18e1c2bb37f2fd",
+        "version" : "2.28.3"
       }
     },
     {

--- a/Cobrowse/AppDelegate.swift
+++ b/Cobrowse/AppDelegate.swift
@@ -18,13 +18,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let cobrowse = CobrowseIO.instance()
         
         cobrowse.license = "trial"
-        cobrowse.start()
-        cobrowse.delegate = session
         
         cobrowse.customData = [
             kCBIOUserEmailKey: "ios@demo.com",
             kCBIODeviceNameKey: "iOS Demo"
         ] as [String : NSObject]
+        
+        cobrowse.webviewRedactedViews = [
+            "#title",
+            "#amount",
+            "#subtitle",
+            "#map"
+        ]
+        
+        cobrowse.delegate = session
+        
+        cobrowse.start()
         
         return true
     }

--- a/Cobrowse/WebContent/index.html
+++ b/Cobrowse/WebContent/index.html
@@ -29,12 +29,6 @@
         </div>
     </div>
 
-    <footer class="fixed bottom-0 left-0 w-full bg-gray-100 border-t border-gray-200 py-2 z-50">
-        <div class="container mx-auto text-gray-500 text-sm text-center">
-          This webview is redacted from the agent.
-        </div>
-      </footer>
-
     <script>
         const getQueryParameter = (name) => {
             const urlParams = new URLSearchParams(window.location.search);

--- a/Cobrowse/WebViewController.swift
+++ b/Cobrowse/WebViewController.swift
@@ -13,7 +13,6 @@ class WebViewController: UIViewController {
     @IBOutlet weak var webView: WKWebView!
 
     var url: URL?
-    var isRedacted = true
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,22 +24,11 @@ class WebViewController: UIViewController {
         guard let url = url
             else { return }
         
-        isRedacted = !url.absoluteString.contains("fraud")
-        
         webView.load(URLRequest(url: url))
     }
 
     @IBAction func sessionButtonWasTapped(_ sender: Any) {
         session.current?.end()
-    }
-}
-
-// MARK: - CobrowseIORedacted
-
-extension WebViewController: CobrowseIORedacted {
-    
-    func redactedViews() -> [Any] {
-        isRedacted ? [webView!] : []
     }
 }
 


### PR DESCRIPTION
Previously the entire web view would be redacted from the agent. Now with the iOS SDK 2.28.0 or above web view elements can now selectively be redacted allowing the agent to see parts of the web content that are not redacted.

For more details please see [https://docs.cobrowse.io/sdk-features/redact-sensitive-data](https://docs.cobrowse.io/sdk-features/redact-sensitive-data).