### PR TITLE
Listen to changes on the session to dismiss the consent prompt if it changes

### DIFF
--- a/Cobrowse/Models/Session+UIKit.swift
+++ b/Cobrowse/Models/Session+UIKit.swift
@@ -32,6 +32,13 @@ extension CobrowseSession {
         consentPrompt.onDeny = { session in session?.end() }
         consentPrompt.onAllow = { session in session?.activate() }
         
+        consentPrompt.onUpdate = { session in
+            guard session == nil
+                else { return }
+            
+            consentPrompt.dismiss(animated: true)
+        }
+        
         consentPrompt.configureSheet()
         
         UIWindow.present(consentPrompt)
@@ -54,6 +61,13 @@ extension CobrowseSession {
         
         consentPrompt.onDeny = { session in session?.setRemoteControl(.rejected) }
         consentPrompt.onAllow = { session in session?.setRemoteControl(.on) }
+        
+        consentPrompt.onUpdate = { session in
+            guard let session, session.remoteControl() != .requested
+                    else { return }
+            
+            consentPrompt.dismiss(animated: true)
+        }
         
         consentPrompt.configureSheet()
         

--- a/Cobrowse/ViewControllers/ConsentPromptViewController.swift
+++ b/Cobrowse/ViewControllers/ConsentPromptViewController.swift
@@ -20,6 +20,7 @@ class ConsentPromptViewController: UIViewController {
     var heading: String?
     var body: NSAttributedString?
     
+    var onUpdate: ((_ session: CBIOSession?) -> ())?
     var onDeny: ((_ session: CBIOSession?) -> ())?
     var onAllow: ((_ session: CBIOSession?) -> ())?
     
@@ -58,11 +59,10 @@ extension ConsentPromptViewController {
     private func subscribeToSession() {
         
         cobrowseSession.$current.sink { [weak self] session in
-            
-            guard let self = self, session == nil
+            guard let self
                 else { return }
             
-            dismiss(animated: true)
+            self.onUpdate?(session)
         }
         .store(in: &bag)
     }


### PR DESCRIPTION
Now if the agent cancels the request it will dismiss the consent if it is showing.