### PR TITLE
chore(ci): use macOS 26

### DIFF
--- a/.github/workflows/appetize.yml
+++ b/.github/workflows/appetize.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2

--- a/.github/workflows/appetize_swiftui.yml
+++ b/.github/workflows/appetize_swiftui.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This fixes Appetize workflow failures like [this one](https://github.com/cobrowseio/cobrowse-sdk-ios-examples/actions/runs/26954642378/job/79528497290). Pre-selected Xcode on macOS 15 no longer comes with iOS runtime installed.